### PR TITLE
fixes reference to ansible-opts args

### DIFF
--- a/bin/kargo
+++ b/bin/kargo
@@ -16,7 +16,7 @@
 #    You should have received a copy of the GNU General Public License
 #    along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
 
-__version__ = '0.2.3'
+__version__ = '0.2.4'
 
 import os
 import argparse
@@ -69,6 +69,11 @@ if __name__ == '__main__':
     )
     subparsers = parser.add_subparsers(help='commands')
 
+    parser.add_argument(
+        '-v', '--version', action='version',
+        version='%(prog)s'+' %s' %  __version__
+    )
+
     # Options shared by all subparsers
     parent_parser = argparse.ArgumentParser(add_help=False)
     parent_parser.add_argument(
@@ -76,10 +81,6 @@ if __name__ == '__main__':
         help='Where the Ansible playbooks are installed'
     )
     parent_parser.add_argument('--config', dest='configfile', help="Config file")
-    parser.add_argument(
-        '--version', action='version',
-        version='%(prog)s'+' %s' %  __version__
-    )
     parent_parser.add_argument(
         '-y', '--assumeyes', default=False, dest='assume_yes', action='store_true',
         help='When a yes/no prompt would be presented, assume that the user entered "yes"'
@@ -177,11 +178,18 @@ if __name__ == '__main__':
         help='Create GCE machines and generate inventory'
     )
     deploy_parser.add_argument(
-        '-k', '--sshkey', dest='ssh_key', help='ssh key for authentication on remote servers'
+        '-k', '--sshkey', dest='ssh_key',
+        help='ssh key for authentication on remote servers'
     )
     deploy_parser.add_argument(
         '-u', '--user', dest='ansible_user', default=getpass.getuser(),
         help='Ansible SSH user (remote user)'
+    )
+    deploy_parser.add_argument(
+        '-N', '--kube-network', dest='kube_network', default='10.233.0.0/16',
+        help="""Network to be used inside the cluster (/16),
+             (must not overlap with any of your infrastructure networks).
+             default: 10.233.0.0/16"""
     )
     deploy_parser.add_argument(
         '-n', '--network-plugin', default='flannel',

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ test_requirements = [
 
 setup(
     name='kargo',
-    version='0.2.3',
+    version='0.2.4',
     description="Kargo kubernetes cluster deployment",
     author="Smaine Kahlouch",
     author_email='smainklh@gmail.com',

--- a/src/kargo/__init__.py
+++ b/src/kargo/__init__.py
@@ -1,3 +1,3 @@
 # (c) 2016, Smaine Kahlouch <smainklh@gmail.com>
 __author__ = 'smana'
-__version__ = '0.2.3'
+__version__ = '0.2.4'

--- a/src/kargo/common.py
+++ b/src/kargo/common.py
@@ -19,6 +19,7 @@
 import logging
 import shutil
 import os
+import netaddr
 import sys
 import string
 import random
@@ -127,3 +128,16 @@ def run_command(description, cmd):
 
 def id_generator(size=6, chars=string.ascii_lowercase + string.digits):
     return ''.join(random.choice(chars) for _ in range(size))
+
+
+def validate_cidr(cidr, version):
+    """
+    Validates that a CIDR is valid. Returns true if valid, false if
+    not. Version can be "4", "6", None for "IPv4", "IPv6", or "either"
+    respectively.
+    """
+    try:
+        ip = netaddr.IPNetwork(cidr, version=version)
+        return True
+    except (netaddr.core.AddrFormatError, ValueError, TypeError):
+        return False

--- a/src/kargo/deploy.py
+++ b/src/kargo/deploy.py
@@ -172,8 +172,8 @@ class RunPlaybook(object):
             sys.exit(1)
         svc_network, pods_network = self.get_subnets()
         # Add any additionnal Ansible option
-        if 'ansible-opts' in self.options.keys():
-            cmd = cmd + self.options['ansible-opts'].split(' ')
+        if 'ansible_opts' in self.options.keys():
+            cmd = cmd + self.options['ansible_opts'].split(' ')
         for cloud in ['aws', 'gce']:
             if self.options[cloud]:
                 cmd = cmd + ['-e', 'cloud_provider=%s' % cloud]


### PR DESCRIPTION
Python [argparse](https://docs.python.org/dev/library/argparse.html#dest) converts dashes (`-`) into lodashes (`_`) in order to generate valid python attributes. Therefore kargo python modules need to reference the `--ansible-opts` as `ansible_opts`.