### PR TITLE
Add support for tags for GCE and AWS (issue #20)

### DIFF
--- a/bin/kargo
+++ b/bin/kargo
@@ -136,6 +136,9 @@ if __name__ == '__main__':
     aws_parser.add_argument(
         '--cluster-name', dest='cluster_name', help='Name of the cluster'
     )
+    aws_parser.add_argument(
+        '--tags', dest='tags', help='List of VM tags of the form \'name=value\'', nargs="+", metavar="NAME=VALUE"
+    )
     aws_parser.add_argument('--add', dest='add_node', action='store_true',
         help="Add node to an existing cluster")
     aws_parser.add_argument(
@@ -167,6 +170,9 @@ if __name__ == '__main__':
     )
     gce_parser.add_argument(
         '--cluster-name', dest='cluster_name', help='Name of the cluster'
+    )
+    gce_parser.add_argument(
+        '--tags', dest='tags', help='List of VM tags', nargs="+", metavar="TAG"
     )
     gce_parser.add_argument('--add', dest='add_node', action='store_true',
         help="Add node to an existing cluster")

--- a/src/kargo/cloud.py
+++ b/src/kargo/cloud.py
@@ -142,10 +142,15 @@ class AWS(Cloud):
         data.pop('func')
         # Options list of ansible EC2 module
         self.options['image'] = self.options['ami']
+        if 'tags' in self.options:
+            self.options['instance_tags'] = {}
+            for kv in self.options['tags']:
+                k, v = kv.split("=")
+                self.options['instance_tags'][k] = v
         ec2_options = [
             'aws_access_key', 'aws_secret_key', 'count', 'group',
             'instance_type', 'key_name', 'region', 'vpc_subnet_id',
-            'image'
+            'image', 'instance_tags'
         ]
         # Define EC2 task
         ec2_task = {'ec2': {},
@@ -187,10 +192,12 @@ class GCE(Cloud):
     def gen_gce_playbook(self):
         data = self.options
         data.pop('func')
+        if 'tags' in self.options:
+            self.options['tags'] = ','.join(self.options['tags'])
         # Options list of ansible GCE module
         gce_options = [
             'machine_type', 'image', 'zone', 'service_account_email',
-            'pem_file', 'project_id'
+            'pem_file', 'project_id', 'tags'
         ]
         # Define instance names
         gce_instance_names = list()

--- a/src/kargo/files/kargo.yml
+++ b/src/kargo/files/kargo.yml
@@ -22,6 +22,8 @@ loglevel: "info"
 # group: "<aws_security_group>"
 # vpc_subnet_id: "<aws_vpc_id>"
 # region: "<aws_region>"
+# tags:
+#   - type: k8s
 #
 # Google Compute Engine options
 # ---
@@ -31,6 +33,8 @@ loglevel: "info"
 # pem_file: "<gce_pem_file>"
 # project_id: "<gce_project_id>"
 # zone: "<cloud_region>"
+# tags:
+#   - k8s
 #
 # All the options to be passed to the 'ansible-playbook' command line
 # ansible-opts:


### PR DESCRIPTION
Add options --tags for GCE and AWS to add tags when the VM are created (issue #20)

#### GCE
```kargo gce --instances 3 --tags k8s preprod```

#### AWS
```kargo aws --instances 3 --tags type=k8s scope=preprod```

Since I'm not a fluent python dev, a code review would be greatly appreciated.