### PR TITLE
Remove forced deployment of flannel

### DIFF
--- a/bin/kargo
+++ b/bin/kargo
@@ -275,8 +275,9 @@ if __name__ == '__main__':
              default: 10.233.0.0/16"""
     )
     deploy_parser.add_argument(
-        '-n', '--network-plugin', default='flannel',
-        choices=['flannel', 'weave', 'calico']
+        '-n', '--network-plugin',
+        choices=['flannel', 'weave', 'calico'],
+        help='Inventory defaults to flannel'
     )
     deploy_parser.add_argument(
         '--aws', default=False, action='store_true',

--- a/src/kargo/deploy.py
+++ b/src/kargo/deploy.py
@@ -184,11 +184,15 @@ class RunPlaybook(object):
         '''
         cmd = [
             playbook_exec, '--ssh-extra-args', '-o StrictHostKeyChecking=no',
-            '-e', 'kube_network_plugin=%s' % self.options['network_plugin'],
             '-u',  '%s' % self.options['ansible_user'],
             '-b', '--become-user=root', '-i', self.inventorycfg,
             os.path.join(self.options['kargo_path'], 'cluster.yml')
         ]
+        # Configure network plugin if defined
+        if self.options['network_plugin']:
+            cmd = cmd + [ '-e',
+                'kube_network_plugin=%s' % self.options['network_plugin']
+            ]
         # Configure the network subnets pods and k8s services
         if 'kube_network' in self.options.keys():
             if not validate_cidr(self.options['kube_network'], version=4):


### PR DESCRIPTION
Flannel will still be the default because
inventory/group_vars/all.yml still defaults to Flannel. A deployer
should be able to update inventory/group_vars/all.yml and deploy
the expected network plugin if he or she did not indicate a
network plugin explicitly.