### PR TITLE
Feature/cleanup aws cli args

### DIFF
--- a/bin/kargo
+++ b/bin/kargo
@@ -92,15 +92,23 @@ if __name__ == '__main__':
     parent_parser = argparse.ArgumentParser(add_help=False)
     parent_parser.add_argument(
         '-p', '--path', dest='kargo_path',
-        help='Where the Ansible playbooks are installed'
+        help='Where the Ansible playbooks are installed. Default: ~/.kargo'
     )
-    parent_parser.add_argument('--config', dest='configfile', help="Config file")
+    parent_parser.add_argument(
+      '--config', dest='configfile',
+      help="Config file path. Defaults to /etc/kargo/kargo.yml"
+    )
     parent_parser.add_argument(
         '-y', '--assumeyes', default=False, dest='assume_yes', action='store_true',
         help='When a yes/no prompt would be presented, assume that the user entered "yes"'
     )
     parent_parser.add_argument(
-        '-i', '--inventory', dest='inventory_path', help='Inventory file path'
+        '-i', '--inventory', dest='inventory_path',
+        help='Inventory file path. Defaults to <path parameter>/inventory/inventory.cfg'
+    )
+    parent_parser.add_argument(
+        '-l', '--logfile', dest='logfile',
+        help='Log file path. Defaults to <path parameter>/kargo.log'
     )
 
     # prepare
@@ -134,8 +142,7 @@ if __name__ == '__main__':
     )
     aws_parser.add_argument('--region', dest='region', help='AWS region')
     aws_parser.add_argument(
-        '--security-group', dest='group',
-        help='AWS security group ID. Uses the "default" security group if not specified.'
+        '--security-group', dest='group', help='AWS security group ID. Uses the "default" security group if not specified.'
     )
     aws_parser.add_argument(
         '--assign-public-ip', default=None, dest='assign_public_ip', action='store_true',
@@ -145,9 +152,9 @@ if __name__ == '__main__':
         '--use-private-ip', default=None, dest='use_private_ip', action='store_true',
          help='If set to true, using the private ip for SSH connection'
     )
-    aws_parser.add_argument('--vpc-id', dest='aws_vpc_id', help='EC2 VPC id')
+    aws_parser.add_argument('--vpc-id', dest='aws_vpc_id', help='EC2 VPC ID')
     aws_parser.add_argument(
-        '--vpc-subnet-id', dest='vpc_subnet_id', help='EC2 VPC regional subnet'
+        '--vpc-subnet-id', dest='vpc_subnet_id', help='EC2 VPC subnet ID'
     )
     aws_parser.add_argument('--ami', dest='ami', help='AWS AMI')
     aws_parser.add_argument(
@@ -307,7 +314,7 @@ if __name__ == '__main__':
     config = C.parse_configfile
     # Set kargo_path
     if 'kargo_path' not in config.keys() and args.kargo_path is None:
-        config['kargo_path'] = os.path.join(os.path.expanduser("~"), 'kargo')
+        config['kargo_path'] = os.path.join(os.path.expanduser("~"), '.kargo')
     arguments = dict(args._get_kwargs())
     for key, value in arguments.items():
         if value is not None:

--- a/bin/kargo
+++ b/bin/kargo
@@ -142,7 +142,7 @@ if __name__ == '__main__':
     )
     aws_parser.add_argument('--region', dest='region', help='AWS region')
     aws_parser.add_argument(
-        '--security-group', dest='group', help='AWS security group ID. Uses the "default" security group if not specified.'
+        '--security-group', dest='security_group', help='AWS security group ID. Uses the "default" security group if not specified.'
     )
     aws_parser.add_argument(
         '--assign-public-ip', default=None, dest='assign_public_ip', action='store_true',

--- a/bin/kargo
+++ b/bin/kargo
@@ -121,20 +121,21 @@ if __name__ == '__main__':
         'aws', parents=[parent_parser, firststep_parser], help='Create AWS instances and generate inventory'
     )
     aws_parser.add_argument(
-        '--access-key', dest='aws_access_key', help='AWS access key'
+        '--aws-access-key', dest='aws_access_key', help='AWS access key'
     )
     aws_parser.add_argument(
-        '--secret-key', dest='aws_secret_key', help='AWS secret key'
+        '--aws-secret-key', dest='aws_secret_key', help='AWS secret key'
     )
     aws_parser.add_argument(
-        '--type', dest='instance_type', help='AWS instance type'
+        '--instance-type', dest='instance_type', help='AWS instance type'
     )
     aws_parser.add_argument(
-        '--keypair', dest='key_name', help='AWS key pair name'
+        '--key-name', dest='key_name', help='AWS key pair name'
     )
     aws_parser.add_argument('--region', dest='region', help='AWS region')
     aws_parser.add_argument(
-        '--security-group', dest='group', help='AWS security group'
+        '--security-group', dest='group',
+        help='AWS security group ID. Uses the "default" security group if not specified.'
     )
     aws_parser.add_argument(
         '--assign-public-ip', default=None, dest='assign_public_ip', action='store_true',
@@ -146,7 +147,7 @@ if __name__ == '__main__':
     )
     aws_parser.add_argument('--vpc-id', dest='aws_vpc_id', help='EC2 VPC id')
     aws_parser.add_argument(
-        '--vpc-subnet', dest='vpc_subnet_id', help='EC2 VPC regional subnet'
+        '--vpc-subnet-id', dest='vpc_subnet_id', help='EC2 VPC regional subnet'
     )
     aws_parser.add_argument('--ami', dest='ami', help='AWS AMI')
     aws_parser.add_argument(

--- a/src/kargo/cloud.py
+++ b/src/kargo/cloud.py
@@ -142,13 +142,14 @@ class AWS(Cloud):
         data.pop('func')
         # Options list of ansible EC2 module
         self.options['image'] = self.options['ami']
+        self.options['group'] = self.options['security_group']
         if 'tags' in self.options:
             self.options['instance_tags'] = {}
             for kv in self.options['tags']:
                 k, v = kv.split("=")
                 self.options['instance_tags'][k] = v
         ec2_options = [
-            'aws_access_key', 'aws_secret_key', 'count', 'security_group',
+            'aws_access_key', 'aws_secret_key', 'count', 'group', 'security_group',
             'instance_type', 'key_name', 'region', 'vpc_subnet_id',
             'image', 'instance_tags', 'assign_public_ip'
         ]

--- a/src/kargo/cloud.py
+++ b/src/kargo/cloud.py
@@ -148,7 +148,7 @@ class AWS(Cloud):
                 k, v = kv.split("=")
                 self.options['instance_tags'][k] = v
         ec2_options = [
-            'aws_access_key', 'aws_secret_key', 'count', 'group',
+            'aws_access_key', 'aws_secret_key', 'count', 'security_group',
             'instance_type', 'key_name', 'region', 'vpc_subnet_id',
             'image', 'instance_tags', 'assign_public_ip'
         ]

--- a/src/kargo/deploy.py
+++ b/src/kargo/deploy.py
@@ -122,7 +122,7 @@ class RunPlaybook(object):
             '-b', '--become-user=root', '-m', 'ping', 'all',
             '-i', self.inventorycfg
         ]
-        if self.options['sshkey']:
+        if 'sshkey' in self.options.keys():
             cmd = cmd + ['--private-key', self.options['sshkey']]
         if self.options['coreos']:
             cmd = cmd + ['-e', 'ansible_python_interpreter=/opt/bin/python']

--- a/src/kargo/deploy.py
+++ b/src/kargo/deploy.py
@@ -122,6 +122,8 @@ class RunPlaybook(object):
             '-b', '--become-user=root', '-m', 'ping', 'all',
             '-i', self.inventorycfg
         ]
+        if self.options['sshkey']:
+            cmd = cmd + ['--private-key', self.options['sshkey']]
         if self.options['coreos']:
             cmd = cmd + ['-e', 'ansible_python_interpreter=/opt/bin/python']
         rcode, emsg = run_command('SSH ping hosts', cmd)

--- a/src/kargo/files/kargo.yml
+++ b/src/kargo/files/kargo.yml
@@ -5,9 +5,11 @@
 
 # Default inventory path
 kargo_git_repo: "https://github.com/kubespray/kargo.git"
+kargo_path: "~/.kargo"
 
 # Logging options
 loglevel: "info"
+logfile: "~/.kargo/kargo.log"
 
 # The following options would be overwritten by the command line
 # ---------------------------------------------------------
@@ -19,7 +21,7 @@ loglevel: "info"
 # key_name: "<aws_keypair_name>"
 # ami: "<aws_ami>"
 # instance_type: "<aws_instance_type>"
-# group: "<aws_security_group>"
+# security_group: "<aws_security_group>"
 # assign_public_ip: True
 # vpc_subnet_id: "<aws_vpc_id>"
 # region: "<aws_region>"


### PR DESCRIPTION
As discussed in Slack and mentioned in #38, I've updated the CLI args for AWS to match the config file options. One exception there though: I've renamed the config hash key name for the AWS security group ID to be "security_group" rather than "group" to take away some of the ambiguity there.

Additionally, I've made a few other changes:
* Updated help text with defaults for some of the AWS options with non-obvious defaults.
* Changed the kargo path to ~/.kargo, which is more in-line with how similar tools operate.
* Added a logfile option to the CLI
* Updated the config file to match the CLI option changes/additions.

Accidentally based this off the branch used for my previous PR which adds the sshkey param to check_ping()... Can rebase to remove that part.