### PR TITLE
[AWS] Added instance_profile_name parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ frequently </br>
     # masters_instance_type: "<masters_instance_type>"
     # nodes_instance_type: "<nodes_instance_type>"
     # etcds_instance_type: "<etcds_instance_type>"
+    # masters_instance_profile_name: "<master_instance_profile_name>"
+    # nodes_instance_profile_name: "<nodes_instance_profile_name>"
+    # etcds_instance_profile_name: "<etcds_instance_profile_name>"
     # security_group_name: "<security_group_name>"
     # security_group_id: "<security_group_id>"
     # assign_public_ip: True

--- a/src/kargo/cloud.py
+++ b/src/kargo/cloud.py
@@ -170,7 +170,7 @@ class AWS(Cloud):
                 self.options['instance_tags'][k] = v
         ec2_options = [
             'aws_access_key', 'aws_secret_key', 'count', 'group_id',
-            'group', 'instance_type', 'key_name', 'vpc_subnet_id',
+            'group', 'instance_type', 'instance_profile_name', 'key_name', 'vpc_subnet_id',
             'image', 'instance_tags', 'assign_public_ip', 'region'
         ]
         # Define EC2 task
@@ -185,6 +185,7 @@ class AWS(Cloud):
                         ec2_task['ec2'].update(d)
                 ec2_task['ec2'].update({'count': self.options['%s_count' % role]})
                 ec2_task['ec2'].update({'instance_type': self.options['%s_instance_type' % role]})
+                ec2_task['ec2'].update({'instance_profile_name': self.options['%s_instance_profile_name' % role]})
                 ec2_task['ec2'].update({'wait': True})
                 self.pbook_content[0]['tasks'].append(ec2_task)
                 # Write ec2 instances json


### PR DESCRIPTION
This PR allow to specify an iam profile name to an instance type (masters/nodes/etcds).
IAM profile should exist, it is not create by kargo